### PR TITLE
[FEATURE] Register dashboards, widgetGroups and widgets by PHP API

### DIFF
--- a/Classes/Configuration/AbstractConfiguration.php
+++ b/Classes/Configuration/AbstractConfiguration.php
@@ -5,7 +5,7 @@ namespace FriendsOfTYPO3\Dashboard\Configuration;
 
 class AbstractConfiguration
 {
-    public function __construct(array $properties)
+    public function __construct(array $properties = [])
     {
         foreach ($properties as $property => $value) {
             if (property_exists($this, $property)) {

--- a/Classes/Configuration/Dashboard.php
+++ b/Classes/Configuration/Dashboard.php
@@ -23,7 +23,7 @@ class Dashboard extends AbstractConfiguration
     /**
      * @var string
      */
-    protected $iconIdentifier = 'dashboard-dashboard';
+    protected $iconIdentifier = 'dashboard-default';
 
     /**
      * @var string
@@ -45,9 +45,25 @@ class Dashboard extends AbstractConfiguration
         return $this->identifier;
     }
 
+    /**
+     * @param string $identifier
+     */
+    public function setIdentifier(string $identifier): void
+    {
+        $this->identifier = $identifier;
+    }
+
     public function getExcludeFromWizard(): bool
     {
         return $this->excludeFromWizard;
+    }
+
+    /**
+     * @param bool $excludeFromWizard
+     */
+    public function setExcludeFromWizard(bool $excludeFromWizard): void
+    {
+        $this->excludeFromWizard = $excludeFromWizard;
     }
 
     public function getIconIdentifier(): string
@@ -55,9 +71,25 @@ class Dashboard extends AbstractConfiguration
         return $this->iconIdentifier;
     }
 
+    /**
+     * @param string $iconIdentifier
+     */
+    public function setIconIdentifier(string $iconIdentifier): void
+    {
+        $this->iconIdentifier = $iconIdentifier;
+    }
+
     public function getLabel(): string
     {
         return $this->label;
+    }
+
+    /**
+     * @param string $label
+     */
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
     }
 
     public function getDescription(): string
@@ -66,10 +98,26 @@ class Dashboard extends AbstractConfiguration
     }
 
     /**
+     * @param string $description
+     */
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    /**
      * @return string[]
      */
     public function getWidgets(): array
     {
         return $this->widgets;
+    }
+
+    /**
+     * @param string[] $widgets
+     */
+    public function setWidgets(array $widgets): void
+    {
+        $this->widgets = $widgets;
     }
 }

--- a/Classes/Configuration/Widget.php
+++ b/Classes/Configuration/Widget.php
@@ -30,9 +30,25 @@ class Widget extends AbstractConfiguration
         return $this->identifier;
     }
 
+    /**
+     * @param string $identifier
+     */
+    public function setIdentifier(string $identifier): void
+    {
+        $this->identifier = $identifier;
+    }
+
     public function getClassname(): string
     {
         return $this->className;
+    }
+
+    /**
+     * @param string $className
+     */
+    public function setClassName(string $className): void
+    {
+        $this->className = $className;
     }
 
     /**
@@ -41,5 +57,13 @@ class Widget extends AbstractConfiguration
     public function getGroups(): array
     {
         return $this->groups;
+    }
+
+    /**
+     * @param string[] $groups
+     */
+    public function setGroups(array $groups): void
+    {
+        $this->groups = $groups;
     }
 }

--- a/Classes/Configuration/WidgetGroup.php
+++ b/Classes/Configuration/WidgetGroup.php
@@ -25,8 +25,24 @@ class WidgetGroup extends AbstractConfiguration
         return $this->identifier;
     }
 
+    /**
+     * @param string $identifier
+     */
+    public function setIdentifier(string $identifier): void
+    {
+        $this->identifier = $identifier;
+    }
+
     public function getLabel(): string
     {
         return $this->label;
+    }
+
+    /**
+     * @param string $label
+     */
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
     }
 }

--- a/Classes/DashboardConfiguration.php
+++ b/Classes/DashboardConfiguration.php
@@ -62,6 +62,13 @@ class DashboardConfiguration implements SingletonInterface
      */
     protected $packageManager;
 
+    /**
+     * Array of all registered dashboards
+     *
+     * @var array
+     */
+    protected $dashboards = [];
+
     public function __construct(PackageManager $packageManager = null)
     {
         $this->packageManager = $packageManager ?? GeneralUtility::makeInstance(PackageManager::class);
@@ -105,13 +112,20 @@ class DashboardConfiguration implements SingletonInterface
      */
     protected function resolveAllExistingDashboards(bool $useCache = true): array
     {
-        $dashboards = [];
         $dashboardConfiguration = $this->getAllDashboardConfigurationFromFiles($useCache);
         foreach ($dashboardConfiguration['Dashboard']['Dashboards'] ?? [] as $configuration) {
-            $dashboards[$configuration['identifier']] = GeneralUtility::makeInstance(Dashboard::class, $configuration);
+            $this->dashboards[$configuration['identifier']] = GeneralUtility::makeInstance(Dashboard::class, $configuration);
         }
-        $this->firstLevelCacheDashboards = $dashboards;
-        return $dashboards;
+        $this->firstLevelCacheDashboards = $this->dashboards;
+        return $this->dashboards;
+    }
+
+    /**
+     * @param Dashboard $dashboardObject
+     */
+    public function registerDashboard(Dashboard $dashboardObject): void
+    {
+        $this->dashboards[$dashboardObject->getIdentifier()] = $dashboardObject;
     }
 
     /**

--- a/Classes/DashboardConfiguration.php
+++ b/Classes/DashboardConfiguration.php
@@ -69,6 +69,10 @@ class DashboardConfiguration implements SingletonInterface
      */
     protected $dashboards = [];
 
+    protected $widgetGroups = [];
+
+    protected $widgets = [];
+
     public function __construct(PackageManager $packageManager = null)
     {
         $this->packageManager = $packageManager ?? GeneralUtility::makeInstance(PackageManager::class);
@@ -105,7 +109,7 @@ class DashboardConfiguration implements SingletonInterface
     }
 
     /**
-     * Resolve all dashboard objects which have been found in the filesystem.
+     * Resolve all dashboard objects which have been found in the filesystem and registered by the API
      *
      * @param bool $useCache
      * @return Dashboard[]
@@ -121,11 +125,11 @@ class DashboardConfiguration implements SingletonInterface
     }
 
     /**
-     * @param Dashboard $dashboardObject
+     * @param Dashboard $dashboardConfiguration
      */
-    public function registerDashboard(Dashboard $dashboardObject): void
+    public function registerDashboard(Dashboard $dashboardConfiguration): void
     {
-        $this->dashboards[$dashboardObject->getIdentifier()] = $dashboardObject;
+        $this->dashboards[$dashboardConfiguration->getIdentifier()] = $dashboardConfiguration;
     }
 
     /**
@@ -136,30 +140,44 @@ class DashboardConfiguration implements SingletonInterface
      */
     protected function resolveAllExistingWidgets(bool $useCache = true): array
     {
-        $widgets = [];
         $dashboardConfiguration = $this->getAllDashboardConfigurationFromFiles($useCache);
         foreach ($dashboardConfiguration['Dashboard']['Widgets'] ?? [] as $configuration) {
-            $widgets[$configuration['identifier']] = GeneralUtility::makeInstance(Widget::class, $configuration);
+            $this->widgets[$configuration['identifier']] = GeneralUtility::makeInstance(Widget::class, $configuration);
         }
-        $this->firstLevelCacheWidgets = $widgets;
-        return $widgets;
+        $this->firstLevelCacheWidgets = $this->widgets;
+        return $this->widgets;
     }
 
     /**
-     * Resolve all widget groups objects which have been found in the filesystem.
+     * @param Widget $widgetConfiguration
+     */
+    public function registerWidget(Widget $widgetConfiguration): void
+    {
+        $this->widgets[$widgetConfiguration->getIdentifier()] = $widgetConfiguration;
+    }
+
+    /**
+     * Resolve all widget groups objects which have been found in the filesystem and registered by the API
      *
      * @param bool $useCache
-     * @return Widget[]
+     * @return WidgetGroup[]
      */
     protected function resolveAllExistingWidgetGroups(bool $useCache = true): array
     {
-        $widgetsGroups = [];
         $dashboardConfiguration = $this->getAllDashboardConfigurationFromFiles($useCache);
         foreach ($dashboardConfiguration['Dashboard']['WidgetGroups'] ?? [] as $configuration) {
-            $widgetsGroups[$configuration['identifier']] = GeneralUtility::makeInstance(WidgetGroup::class, $configuration);
+            $this->widgetGroups[$configuration['identifier']] = GeneralUtility::makeInstance(WidgetGroup::class, $configuration);
         }
-        $this->firstLevelCacheWidgetGroups = $widgetsGroups;
-        return $widgetsGroups;
+        $this->firstLevelCacheWidgetGroups = $this->widgetGroups;
+        return $this->widgetGroups;
+    }
+
+    /**
+     * @param WidgetGroup $widgetGroupConfiguration
+     */
+    public function registerWidgetGroup(WidgetGroup $widgetGroupConfiguration): void
+    {
+        $this->widgetGroups[$widgetGroupConfiguration->getIdentifier()] = $widgetGroupConfiguration;
     }
 
     /**

--- a/Resources/Private/Templates/Dashboard/Main.html
+++ b/Resources/Private/Templates/Dashboard/Main.html
@@ -8,7 +8,7 @@
         <f:if condition="{availableDashboards -> f:count()} > 1">
             <f:for each="{availableDashboards}" as="dashboardConfig" key="dashboardKey">
                 <f:be.link route="dashboard" parameters="{action: 'setActiveDashboard', currentDashboard: dashboardKey}" class="dashboardTab {f:if(condition: '{dashboardKey} == {currentDashboard}', then: 'dashboardTab--active')}">
-                    <f:translate key="{dashboardConfig.label}"/>
+                    <f:translate key="{dashboardConfig.label}" default="{dashboardConfig.label}"/>
                 </f:be.link>
             </f:for>
         </f:if>

--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,6 @@
     "symfony/finder": "^4.3",
     "typo3fluid/fluid": "^2.5"
   },
-  "conflict": {
-    "symfony/yaml": "4.4.0"
-  },
   "autoload": {
     "psr-4": {
       "FriendsOfTYPO3\\Dashboard\\": "Classes/"

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
     "symfony/finder": "^4.3",
     "typo3fluid/fluid": "^2.5"
   },
+  "conflict": {
+    "symfony/yaml": "4.4.0"
+  },
   "autoload": {
     "psr-4": {
       "FriendsOfTYPO3\\Dashboard\\": "Classes/"


### PR DESCRIPTION
Besides registering dashboards, widgetGroups and widgets by the Dashboard.yaml file, you can now register dashboards, widgetGroups and widgets by a PHP API as well. 

An example how to use this API:
```
$newDashboard = GeneralUtility::makeInstance(\FriendsOfTYPO3\Dashboard\Configuration\Dashboard::class);
$newDashboard->setIdentifier('dashboard-new');
$newDashboard->setLabel('Label of dashboard');
$newDashboard->setDescription('Description of dashboard');

$newWidgetGroup = GeneralUtility::makeInstance(\FriendsOfTYPO3\Dashboard\Configuration\WidgetGroup::class);
$newWidgetGroup->setIdentifier('widgetGroup-new');
$newWidgetGroup->setLabel('Widget group');

$newWidget = GeneralUtility::makeInstance(\FriendsOfTYPO3\Dashboard\Configuration\Widget::class);
$newWidget->setIdentifier('widget-new');
$newWidget->setClassName(NumberOfAdminBackendUsersWidget::class);
$newWidget->setGroups(['widgetGroup-new']);

$dashboardConfiguration = GeneralUtility::makeInstance(\FriendsOfTYPO3\Dashboard\DashboardConfiguration::class);
$dashboardConfiguration->registerDashboard($newDashboard);
$dashboardConfiguration->registerWidgetGroup($newWidgetGroup);
$dashboardConfiguration->registerWidget($newWidget);
```

Resolves: #102 